### PR TITLE
fix(likedislike): ignore unknown state for like/dislike state due to ytmd native issues

### DIFF
--- a/src/actions/like-dislike.action.ts
+++ b/src/actions/like-dislike.action.ts
@@ -5,6 +5,7 @@ import {LikeStatus, StateOutput} from 'ytmdesktop-ts-companion';
 
 export class LikeDislikeAction extends DefaultAction<LikeDislikeAction> {
     private events: { context: string, method: (state: StateOutput) => void }[] = [];
+    private lastLikeStatus: LikeStatus = LikeStatus.UNKNOWN;
 
     constructor(
         private plugin: YTMD,
@@ -64,7 +65,16 @@ export class LikeDislikeAction extends DefaultAction<LikeDislikeAction> {
             return;
         }
 
-        const correctState: boolean = data.video.likeStatus === this.likeStatus;
+        const {likeStatus} = data.video;
+        if (likeStatus === LikeStatus.UNKNOWN) {
+            return;
+        }
+
+        if (this.lastLikeStatus === likeStatus) {
+            return;
+        }
+
+        const correctState: boolean = likeStatus === this.likeStatus;
         this.plugin.setState(correctState ? StateType.ON : StateType.OFF, context);
     }
 }


### PR DESCRIPTION
This commit adds current state caching for like/dislike state and ignores the unknown one. This is due to an issue in the YTMDesktop application.

fixes #116