### PR TITLE
fix: set image crossOrigin to `anonymous` to avoid CORS restrictions and update streamdeck-typescript to the same end

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5210,9 +5210,9 @@
       "dev": true
     },
     "node_modules/streamdeck-typescript": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/streamdeck-typescript/-/streamdeck-typescript-3.2.1.tgz",
-      "integrity": "sha512-55+x40oJ323UXfDf1RQ/JuKYgc2DTwNyTkzHpWxDd8nya9X9BdUolULdfh5VL3yktR73OWCxZny32mvq6uKMVA=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/streamdeck-typescript/-/streamdeck-typescript-3.3.4.tgz",
+      "integrity": "sha512-ncxVurGEN0BaIFfQnwSKFgQpTfk0y269h9efmr54hlZs/BRRqpbbU+eoF0K/Mt1sNoGHnehS0zZi8V9NRKXaMA=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/src/actions/play-pause.action.ts
+++ b/src/actions/play-pause.action.ts
@@ -194,6 +194,7 @@ export class PlayPauseAction extends DefaultAction<PlayPauseAction> {
             {
                 this.currentThumbnail = cover;
                 let image = new Image();
+                image.crossOrigin = "anonymous";
 
                 image.onload = () => {
                     let canvas = document.createElement('canvas');


### PR DESCRIPTION
Following up from XeroxDev/Stream-Deck-TS-SDK#24